### PR TITLE
#148 - group if_relevant and if(c,a,b) on their condition

### DIFF
--- a/server/src/main/scala/com/sparkutils/quality/impl/RuleRunner.scala
+++ b/server/src/main/scala/com/sparkutils/quality/impl/RuleRunner.scala
@@ -209,7 +209,10 @@ private[quality] object RuleRunnerUtils extends RuleRunnerImports {
     val resNull = ctx.freshName("isNull")
 
     val groups = RuleRunnerUtils.generateFunctionGroups(ctx, runner, paramInfo, resultRow,
-      Seq((VariableValue(resultRow, classOf[InternalRow]), false)), allExpr)
+      // the runner must be passed in: groupers compile group bodies into separate classes, where
+      // the enclosing class's runner field does not exist
+      Seq((VariableValue(resultRow, classOf[InternalRow]), false),
+        (VariableValue(inPlaceOffsets.runner, inPlaceOffsets.runnerClazz), false)), allExpr)
 
     val funNames: Iterator[String] = groups.groupCalls
 
@@ -219,7 +222,7 @@ private[quality] object RuleRunnerUtils extends RuleRunnerImports {
       code"""
       // copy row
       $resultRowCopy
-      ${funNames.map { f => s"$f($paramsCall);" }.mkString("\n")}
+      ${funNames.map { f => s"$f(${groups.usedParameters.paramsCall});" }.mkString("\n")}
 
       InternalRow ${exp.value} = $resultRow;
       boolean ${exp.isNull} = false;
@@ -307,7 +310,9 @@ trait RuleRunnerBase[T] extends NonSQLExpression with SplitCompilation with Trig
             ruleRunnerExpressionIdx
           )
 
-      GenerateResult((params, classOf[RuleRunnerBase[T]].getName), res, Seq.empty)
+      // groupers emit their group bodies as extra classes and those must be forwarded,
+      // empty for the DefaultTriggerGrouper
+      GenerateResult((params, classOf[RuleRunnerBase[T]].getName), res, triggerRes.extraClasses)
     }
     setClazzSource(clazz)
     fres

--- a/server/src/main/scala/com/sparkutils/quality/impl/Triggers.scala
+++ b/server/src/main/scala/com/sparkutils/quality/impl/Triggers.scala
@@ -365,9 +365,18 @@ trait GroupBasedGrouper extends TriggerGrouper {
         ""
 
     // if ruleEngine is used salience may need comparison, if it's expression or dq any comparison is meaningless
-    code"""
+    val salienceCheck = groupSalienceCheck(group.lowestSalience.toString)
+
+    // dq and expression runners pass an empty check, and `if () {` is not valid java
+    if (salienceCheck.toString.trim.isEmpty)
+      code"""
       // code for $context
-      if (${groupSalienceCheck(group.lowestSalience.toString)}) {
+      $block
+      """
+    else
+      code"""
+      // code for $context
+      if ($salienceCheck) {
         $block
       } $earlyExit
     """

--- a/server/src/main/scala/com/sparkutils/quality/impl/Triggers.scala
+++ b/server/src/main/scala/com/sparkutils/quality/impl/Triggers.scala
@@ -49,12 +49,22 @@ case class Groups(groups: Seq[Group]) extends GroupOr {
 
 case class Trigger(expression: Expression, index: Int, salience: Int, outputExpression: Option[Expression] = None)
 
-case class Group(groupFilter: Expression, lowestSalience: Int, payload: GroupOr) extends LowestSalience {
+/**
+ * @param filterFalseResults (trigger index, result) to write when groupFilter is false, only
+ *                           needed where that case has a meaningful answer differing from the
+ *                           runner's defaultRuleResult - if_relevant yields IgnoredRule, if(c,a,b)
+ *                           yields b.  Empty for And derived filters, there filter false means the
+ *                           conjunction is false so the rule did not trigger.
+ */
+case class Group(groupFilter: Expression, lowestSalience: Int, payload: GroupOr,
+                 filterFalseResults: Seq[(Int, Expression)] = Seq.empty) extends LowestSalience {
   def size = payload.size + 1
 
   def optimisedSize = payload.optimisedSize + 1
 
   def groupFilters: Seq[Expression] = payload.groupFilters :+ groupFilter
+
+  def filterFalseExpressions: Seq[Expression] = filterFalseResults.map(_._2)
 }
 
 case class TriggerResult(groupCalls: Iterator[String], subExpressions: String,
@@ -281,8 +291,8 @@ trait GroupBasedGrouper extends TriggerGrouper {
             groupDepth: Int, outerParams: ParameterInformation,
             returnIfGroupSalienceCheckFalse: Boolean,
             shouldReturn: String, groups: Seq[Group])
-          , allGroupExprs,
-          returnIfGroupSalienceCheckFalse, shouldReturn, outerParams)
+          , allGroupExprs ++ group.filterFalseExpressions,
+          returnIfGroupSalienceCheckFalse, shouldReturn, outerParams, map)
 
       (
         returnIfSalience(groupSalienceCheck, returnIfGroupSalienceCheckFalse,
@@ -307,8 +317,9 @@ trait GroupBasedGrouper extends TriggerGrouper {
             map: Map[Int, (CodegenContext, ParameterInformation, Expression, Boolean) => Block],
             groupDepth: Int, outerParams: ParameterInformation,
             returnIfGroupSalienceCheckFalse: Boolean,
-            shouldReturn: String, triggers: Seq[Trigger]), allGroupExprs,
-          returnIfGroupSalienceCheckFalse, shouldReturn, outerParams)
+            shouldReturn: String, triggers: Seq[Trigger]),
+          allGroupExprs ++ group.filterFalseExpressions,
+          returnIfGroupSalienceCheckFalse, shouldReturn, outerParams, map)
 
       (body.code, clazzes, widerAdditionalParams)
     }
@@ -388,7 +399,9 @@ trait GroupBasedGrouper extends TriggerGrouper {
                                      produceTriggerResult: (CodegenContext, ParameterInformation, String) => TriggerResult,
                                      allGroupExprs: Seq[Expression],
                                      returnIfGroupSalienceCheckFalse: Boolean, shouldReturn: String,
-                                     outerParams: ParameterInformation
+                                     outerParams: ParameterInformation,
+                                     // writes the filter-false branch, the same map the payload uses
+                                     triggerResultWriter: Map[Int, (CodegenContext, ParameterInformation, Expression, Boolean) => Block]
                                     ): (Block, Seq[(Int, CodeAndComment)], ParameterInformation) = {
     val groupIndex = idHolder.next()
     val id = s"Group$groupIndex"
@@ -443,6 +456,20 @@ trait GroupBasedGrouper extends TriggerGrouper {
 
     val eval = group.groupFilter.genCode(ctx)
 
+    // a skipped group leaves the runner's defaultRuleResult in place, which is wrong where the
+    // construct has a meaningful answer for the filter-false case, so write those explicitly
+    val filterFalseBranch =
+      if (group.filterFalseResults.isEmpty)
+        ""
+      else
+        s"""
+           else {
+              ${group.filterFalseResults.map { case (triggerIndex, resultExpr) =>
+                  triggerResultWriter(triggerIndex).apply(ctx, outerParams, resultExpr, false).code
+                }.mkString("\n")}
+           }
+           """
+
     // if ruleEngine is used salience may need comparison, if it's expression or dq any comparison is meaningless
     (
       returnIfSalience(groupSalienceCheck, returnIfGroupSalienceCheckFalse,
@@ -452,6 +479,7 @@ trait GroupBasedGrouper extends TriggerGrouper {
         if ((!${eval.isNull}) && ${eval.value} ) {
           ${expr.code}
         }
+        $filterFalseBranch
         """
       ), body, compilationParams)
   }

--- a/server/src/main/scala/com/sparkutils/quality/impl/util/TopLevelBoolean.scala
+++ b/server/src/main/scala/com/sparkutils/quality/impl/util/TopLevelBoolean.scala
@@ -2,8 +2,9 @@ package com.sparkutils.quality.impl.util
 
 import com.sparkutils.quality.{groupProcessorAuditBucketStep, groupProcessorAuditMaxBucket, groupProcessorAuditMinBucket, groupProcessorBucketSizeKey, groupProcessorPercentFilter}
 import com.sparkutils.quality.impl.util.ExtraConfig.ConfigMapOps
-import com.sparkutils.quality.impl.{Group, Groups, Runner, Trigger, Triggers}
-import org.apache.spark.sql.catalyst.expressions.{Abs, And, EqualTo, Expression, Literal, Murmur3Hash, Or, Remainder}
+import com.sparkutils.quality.impl.{Group, Groups, IfRelevantExpr, Runner, Trigger, Triggers}
+import com.sparkutils.quality.impl.imports.ClassicRuleResultsImports.IgnoredRuleExpr
+import org.apache.spark.sql.catalyst.expressions.{Abs, And, EqualTo, Expression, If, Literal, Murmur3Hash, Or, Remainder}
 import org.apache.spark.sql.types.{BooleanType, IntegerType, StringType}
 
 import scala.collection.mutable.ArrayBuffer
@@ -244,6 +245,13 @@ object TopLevelBoolean {
         t.copy(expression = removeTopLevels(groupParts, t.expression))).sortBy(_.salience)
     }
 
+    // must be called with the original triggers: removeTopLevels rewrites the matched filter to
+    // Literal(true), after which the if_relevant / if shape is gone
+    def filterFalseFor(pop: Iterable[Trigger], groupFilter: Expression): Seq[(Int, Expression)] =
+      pop.toSeq.flatMap { t =>
+        filterFalseResultFor(groupFilter, t.expression).map(t.index -> _)
+      }
+
     val topHitter =
       orderedLarger.foldLeft(Seq.empty[Group]) {
         case (cur, (sub, (groupParts, triggers))) =>
@@ -283,10 +291,15 @@ object TopLevelBoolean {
 
                   if (bucketed.size == 1 && differentiator.bucketer(0,numberOfBuckets) == Literal(true)) {
                     // if it's "true" lift it back up
-                    val corrected = addSeen(bucketed.head._2.map(_._2), groupParts)
+                    val originals = bucketed.head._2.map(_._2)
+                    val filterFalse = filterFalseFor(originals, sub)
+                    val corrected = addSeen(originals, groupParts)
                     val lowest = corrected.minBy(_.salience).salience
-                    Seq(Group(sub, lowest, Triggers(corrected, lowest)))
-                  } else
+                    Seq(Group(sub, lowest, Triggers(corrected, lowest), filterFalse))
+                  } else {
+                    // inner groups key on bucketedExp, so sub's filter-false results belong to
+                    // the outer group
+                    val outerFilterFalse = filterFalseFor(triggers, sub)
                     Seq(Group(sub, triggers.minBy(_.salience).salience, Groups(
                       bucketed.foldLeft(Seq.empty[Group]){
                         case (cur, (bucket, trips)) =>
@@ -296,15 +309,17 @@ object TopLevelBoolean {
                           val lowest = corrected.minBy(_.salience).salience
                           cur :+ Group(bucketedExp, lowest, Triggers(corrected, lowest))
                       }.sortBy(_.lowestSalience)
-                    )))
+                    ), outerFilterFalse))
+                  }
               }
             cur ++ newSeqs
           } else if (triggers.size > 4) { // TODO random number
             // very small groups are expensive and should fall to the true bucket
             // likely no benefit in reducing further
+            val filterFalse = filterFalseFor(triggers, sub)
             val newTriggers = addSeen(triggers, groupParts)
             val lowest = newTriggers.minBy(_.salience).salience
-            cur :+ Group(sub, lowest, Triggers(newTriggers, lowest))
+            cur :+ Group(sub, lowest, Triggers(newTriggers, lowest), filterFalse)
           } else
             cur
       }
@@ -338,10 +353,53 @@ object TopLevelBoolean {
     // TODO: intentionally excluded from subexpression elimination
     case _: Or => Set.empty
     case And(left, right) => fromParts(left) ++ fromParts(right)
+    // if_relevant is IntegerType, so the BooleanType case below never sees it.  Its filter is
+    // only groupable because Group carries filterFalseResults, see filterFalseResultFor.
+    // A nullable filter cannot be grouped: if_relevant answers Failed for a null filter but the
+    // generated branch is `if ((!isNull) && value)`, which cannot tell null from false.
+    case IfRelevantExpr(filter, _) if filter.dataType == BooleanType && !filter.nullable =>
+      fromParts(filter)
+    case If(predicate, trueValue, falseValue)
+      if predicate.dataType == BooleanType &&
+         trueValue.dataType == BooleanType &&
+         falseValue.dataType == BooleanType =>
+      fromParts(predicate)
     case e: Expression if e.dataType == BooleanType =>
       Set(e)
     case _ => Set.empty
   }
+
+  /**
+   * True when groupFilter is the whole of condition, or one of its top level And conjuncts.
+   *
+   * fromParts recurses into a composite filter and the frequency filter in `from` then keeps only
+   * the shared conjuncts, so the group filter is regularly a strict subset of the condition it was
+   * lifted out of.  A conjunct being false still makes the whole conjunction false, so the
+   * filter-false answer is the same either way.
+   */
+  private def coversCondition(groupFilter: Expression, condition: Expression): Boolean =
+    condition match {
+      case _ if condition.semanticEquals(groupFilter) => true
+      case And(left, right) => coversCondition(groupFilter, left) || coversCondition(groupFilter, right)
+      case _ => false
+    }
+
+  /**
+   * The result a trigger must produce when a grouped filter is false, None where the runner's
+   * defaultRuleResult is already correct (And derived filters and anything else).
+   *
+   * @param groupFilter the expression lifted out of the trigger into the group
+   * @param original    the trigger expression before removeTopLevels rewrote it
+   */
+  def filterFalseResultFor(groupFilter: Expression, original: Expression): Option[Expression] =
+    original match {
+      // a nullable filter answers Failed for null, the else branch cannot express that
+      case IfRelevantExpr(filter, _) if !filter.nullable && coversCondition(groupFilter, filter) =>
+        Some(IgnoredRuleExpr)
+      case If(predicate, _, falseValue) if coversCondition(groupFilter, predicate) =>
+        Some(falseValue)
+      case _ => None
+    }
 
   private def from(expression: Expression, t: Expression => Set[Expression], p: Expression => Boolean): Set[Expression] = {
     val resDiff = t(expression).filter(p)

--- a/server/src/test/scala/com/sparkutils/qualityTests/classicOnly/TopLevelBooleanFilterFalseTest.scala
+++ b/server/src/test/scala/com/sparkutils/qualityTests/classicOnly/TopLevelBooleanFilterFalseTest.scala
@@ -1,0 +1,155 @@
+package com.sparkutils.qualityTests.classicOnly
+
+import com.sparkutils.quality._
+import com.sparkutils.quality.impl.IfRelevantExpr
+import com.sparkutils.quality.impl.imports.ClassicRuleResultsImports.IgnoredRuleExpr
+import com.sparkutils.quality.impl.imports.RuleResultsImports.IgnoredRuleInt
+import com.sparkutils.quality.impl.util.TopLevelBoolean
+import com.sparkutils.qualityTests.util.ClassicSharedTests
+import com.sparkutils.testing.ConnectionType
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.{And, BoundReference, EqualTo, Expression, GreaterThan, If, LessThan, Literal}
+import org.apache.spark.sql.types.IntegerType
+import org.scalatest.Matchers
+
+/**
+ * #148 - top level boolean grouping of if_relevant and if(bool,bool,bool), and grouping with the
+ * dq ruleRunner at all, every other grouping test uses ruleEngineRunner.
+ *
+ * A group is only entered when its filter is true, when false the rules keep the runner's
+ * defaultRuleResult.  That is right for And derived filters, where filter false means the
+ * conjunction is false so the rule did not trigger, but wrong for if_relevant where filter false
+ * has the meaningful answer IgnoredRule, hence Group.filterFalseResults.
+ */
+class TopLevelBooleanFilterFalseTest extends ClassicSharedTests with Matchers {
+
+  override val runWith: ConnectionType = com.sparkutils.testing.ClassicOnly
+
+  private val bA = BoundReference(0, IntegerType, nullable = false)
+  private val bB = BoundReference(1, IntegerType, nullable = false)
+  private val filter = GreaterThan(bA, Literal(0))
+  private val cond = EqualTo(bB, Literal(1))
+
+  // a = -1 so the filter is false, b = 1 so the cond is true
+  private val filterFalseRow = InternalRow(-1, 1)
+
+  test("And groups both top level booleans and needs no filter false result") {
+    val e = And(filter, cond)
+    TopLevelBoolean.fromParts(e).size shouldBe 2
+    TopLevelBoolean.filterFalseResultFor(filter, e) shouldBe None
+  }
+
+  test("if_relevant offers its filter and answers IgnoredRule for filter false") {
+    val e = IfRelevantExpr(filter, cond)
+    e.dataType shouldBe IntegerType
+    TopLevelBoolean.fromParts(e) should contain(filter: Expression)
+    TopLevelBoolean.filterFalseResultFor(filter, e).map(_.eval(filterFalseRow)) shouldBe Some(IgnoredRuleInt)
+  }
+
+  test("if(c,a,b) offers its condition and answers the else branch for filter false") {
+    val elseBranch = EqualTo(bB, Literal(99))
+    val e = If(filter, cond, elseBranch)
+    TopLevelBoolean.fromParts(e) should contain(filter: Expression)
+    TopLevelBoolean.filterFalseResultFor(filter, e) shouldBe Some(elseBranch)
+  }
+
+  test("a filter false result is only claimed when the group filter is the condition") {
+    val unrelated = GreaterThan(bB, Literal(42))
+    TopLevelBoolean.filterFalseResultFor(unrelated, IfRelevantExpr(filter, cond)) shouldBe None
+  }
+
+  // fromParts recurses into a composite filter and the frequency filter in `from` keeps only the
+  // shared conjuncts, so the group filter is regularly one conjunct of the if_relevant filter
+  // rather than the whole of it.  A conjunct being false still makes the conjunction false, so
+  // IgnoredRule is still the answer -- semanticEquals alone missed this and emitted no else
+  // branch, leaving the rule on the runner's defaultRuleResult (Passed for dq).
+  test("a conjunct of a composite if_relevant filter still claims IgnoredRule") {
+    val other = LessThan(bB, Literal(10))
+    val e = IfRelevantExpr(And(filter, other), cond)
+
+    TopLevelBoolean.filterFalseResultFor(filter, e) shouldBe Some(IgnoredRuleExpr)
+    TopLevelBoolean.filterFalseResultFor(other, e) shouldBe Some(IgnoredRuleExpr)
+    TopLevelBoolean.filterFalseResultFor(And(filter, other), e) shouldBe Some(IgnoredRuleExpr)
+    // still nothing for an expression that is not part of the filter at all
+    TopLevelBoolean.filterFalseResultFor(GreaterThan(bB, Literal(42)), e) shouldBe None
+  }
+
+  test("a conjunct of a composite if condition still claims the else branch") {
+    val other = LessThan(bB, Literal(10))
+    val elseBranch = EqualTo(bB, Literal(99))
+    val e = If(And(filter, other), cond, elseBranch)
+
+    TopLevelBoolean.filterFalseResultFor(filter, e) shouldBe Some(elseBranch)
+    TopLevelBoolean.filterFalseResultFor(other, e) shouldBe Some(elseBranch)
+    TopLevelBoolean.filterFalseResultFor(GreaterThan(bB, Literal(42)), e) shouldBe None
+  }
+
+  // the nullable guard must survive the conjunct widening above
+  test("a conjunct of a nullable composite if_relevant filter claims nothing") {
+    val nullablePart = GreaterThan(BoundReference(0, IntegerType, nullable = true), Literal(0))
+    val e = IfRelevantExpr(And(nullablePart, filter), cond)
+    TopLevelBoolean.filterFalseResultFor(nullablePart, e) shouldBe None
+    TopLevelBoolean.filterFalseResultFor(filter, e) shouldBe None
+  }
+
+  // if_relevant answers Failed for a null filter and IgnoredRule for a false one, the generated
+  // branch is `if ((!isNull) && value)` so both go to the else, which can only write one answer
+  test("a nullable if_relevant filter is not grouped") {
+    val nullable = GreaterThan(BoundReference(0, IntegerType, nullable = true), Literal(0))
+    val e = IfRelevantExpr(nullable, cond)
+    TopLevelBoolean.fromParts(e) should not contain (nullable: Expression)
+    TopLevelBoolean.filterFalseResultFor(nullable, e) shouldBe None
+  }
+
+  test("removing the top level alone changes the answer, hence the else branch") {
+    val e = IfRelevantExpr(filter, cond)
+    val rewritten = TopLevelBoolean.removeTopLevels(Set[Expression](filter), e)
+    rewritten should not be e
+    e.eval(filterFalseRow) shouldBe IgnoredRuleInt
+    rewritten.eval(filterFalseRow) should not be e.eval(filterFalseRow)
+  }
+
+  private val ruleCount = 40
+
+  private def suiteOf(expr: Int => String) =
+    RuleSuite(Id(10, 2), Seq(RuleSet(Id(20, 1),
+      (for { i <- 0 until ruleCount } yield Rule(Id(1000 + i, 1), ExpressionRule(expr(i)))).toSeq)))
+
+  private def runIt(rs: RuleSuite, extra: Map[String, String]): Seq[RuleResult] = {
+    import com.sparkutils.quality.implicits._
+    val processed = sparkSession.range(0, 100).select(ruleRunner(rs, extraConfig = extra).as("res"))
+    val res = processed.selectExpr("res.*").as[RuleSuiteResult].collect().head
+    res.ruleSetResults.head._2.ruleResults.toSeq.sortBy(_._1.id).map(_._2)
+  }
+
+  private val grouping = Map(
+    groupProcessorKey -> topLevelBooleanGrouper,
+    groupProcessorPercentFilter -> "0.1"
+  )
+
+  /** many rules sharing one filter so the grouper buckets them */
+  private def groupedAgreesWithUngrouped(expr: Int => String)(check: Seq[RuleResult] => Unit): Unit =
+    not3_0_or_3_1 {
+      val rs = suiteOf(expr)
+      val ungrouped = runIt(rs, Map.empty)
+      ungrouped should have size ruleCount
+      check(ungrouped)
+      runIt(rs, grouping) shouldBe ungrouped
+    }
+
+  test("grouped And derived rules agree with ungrouped") {
+    // the dq runner's own grouping codegen, no if_relevant involved
+    groupedAgreesWithUngrouped(i => s"id >= 0 and id >= $i")(_ => ())
+  }
+
+  test("grouped if_relevant agrees with ungrouped, filter false is IgnoredRule") {
+    // without filterFalseResults the grouped run answers Passed
+    groupedAgreesWithUngrouped(i => s"if_relevant(id > 100000, id >= $i)")(
+      _.distinct shouldBe Seq(IgnoredRule))
+  }
+
+  test("grouped if_relevant with a nullable filter agrees with ungrouped") {
+    groupedAgreesWithUngrouped(i =>
+      s"if_relevant(if(id % 2 = 0, cast(null as boolean), id > 100000), id >= $i)")(_ => ())
+  }
+}


### PR DESCRIPTION
Closes #148 — top level boolean grouping for `if_relevant` and `if(c,a,b)`.

## Why

A group body is only entered when its filter is true. When the filter is false the
rule is never evaluated and keeps the runner's `defaultRuleResult`, which is
`PassedInt` for the dq `RuleRunner`. That is sound for an `And` derived filter —
filter false means the conjunction is false, so the rule would not have triggered —
but wrong for a construct that has a meaningful answer for the filter-false case:

```
if_relevant(a > 0, b = 1) with a = -1   must be IgnoredRule (-3)
rewritten to if_relevant(true, b = 1)   would be Passed (1)
```

so an ignoredRule silently became a pass in dq aggregates.

## Changes

**`baa91209d` make the grouper work with the dq ruleRunner** — grouping was only
ever exercised through `ruleEngineRunner`. Three codegen faults on `RuleRunner`,
each masking the next: an empty `groupSalienceCheck` emitting `if () {`, group
calls using the stale outer `paramsCall`, and `extraClasses` dropped so the
grouper's generated classes were missing. `RuleEngineRunner` already did the right
thing in every case.

**`6f4f9214b` group if_relevant and if(c,a,b) on their condition** — `Group` now
carries `filterFalseResults: Seq[(Int, Expression)]`, written in an `else` branch.
`filterFalseResultFor` supplies `IgnoredRuleExpr` for `if_relevant` and the else
branch for `If`, `None` otherwise, so every existing path generates identical code.
Two guards:

- a **nullable** filter is left ungrouped — `if_relevant` answers Failed for a null
  filter, but the generated `if ((!isNull) && value)` sends null and false to the
  same else, which can only write one answer
- the group filter is usually a **subset** of the condition, not all of it —
  `fromParts` recurses into a composite filter and the frequency filter in `from`
  keeps only the shared conjuncts. `coversCondition` therefore matches the whole
  condition or any top level `And` conjunct; a conjunct being false still makes the
  conjunction false, so the answer is unchanged. A `semanticEquals` check alone
  missed this and emitted no else branch

`filterFalseFor` must be called on the original triggers, before `removeTopLevels`
rewrites the matched filter to `Literal(true)`.

**`263cfe2fa` tests** — `TopLevelBooleanFilterFalseTest`, unit cases for
`fromParts`/`filterFalseResultFor` plus grouped vs ungrouped end to end on the dq
ruleRunner.

## Verification

Spark41 / localDev: `TopLevelBooleanFilterFalseTest` 12, `BooleanGrouperTest` 4,
`BaseFunctionalityTest` 35, `SubExpressionEliminationTest` 11, `CodeGenTest` 2 —
all passing. Each commit builds on its own.

Negative controls: reverting the conjunct handling fails 2 of the new tests,
reverting either half of the nullable guard fails another. The subset shapes that
escape `apply()`'s `collectLeaves().size > 2` gate are a 3-leaf shared conjunct and
2 surviving conjuncts of 3; a 2-leaf conjunct like `a > 0` is gated out, which is
why the narrower check appeared to work.

Not yet run: the full 59-suite pass and BigRules. `Triggers.scala` codegen is shared
by every runner, so those are worth a look before merge.
